### PR TITLE
build: Let the verity signer and metadata builders ask for a password

### DIFF
--- a/tools/releasetools/build_image.py
+++ b/tools/releasetools/build_image.py
@@ -111,10 +111,14 @@ def BuildVerityMetadata(image_size, verity_metadata_path, root_hash, salt,
   cmd = cmd_template % (image_size, verity_metadata_path, root_hash, salt,
                         block_device, signer_path, key)
   print(cmd)
-  status, output = getstatusoutput(cmd)
-  if status:
-    print("Could not build verity metadata! Error: %s" % output)
+  runcmd = ["system/extras/verity/build_verity_metadata.py", image_size, verity_metadata_path, root_hash, salt, block_device, signer_path, key];
+  sp = subprocess.Popen(runcmd)
+  sp.wait()
+
+  if sp.returncode != 0:
+    print("Could not build verity metadata!")
     return False
+
   return True
 
 def Append2Simg(sparse_image_path, unsparse_image_path, error_message):

--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -480,7 +480,7 @@ def BuildBootableImage(sourcedir, fs_config_file, info_dict=None):
     cmd.extend([path, img.name,
                 info_dict["verity_key"] + ".pk8",
                 info_dict["verity_key"] + ".x509.pem", img.name])
-    p = Run(cmd, stdout=subprocess.PIPE)
+    p = Run(cmd)
     p.communicate()
     assert p.returncode == 0, "boot_signer of %s image failed" % path
 


### PR DESCRIPTION
Don't grab stdin/out for these tools. We want to know when a password
is being requested (and be able to actually provide one) if the corresponding
key needs it

Change-Id: I8dd439322b7d8942adc9ce7ce0912fb20c69654f
Ref: CYNGNOS-3156